### PR TITLE
✨ make namespace cyan

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,5 @@
+import * as chalk from 'chalk';
+
 export enum LogLevel {
   ERROR = 'error',
   WARN = 'warn',
@@ -15,4 +17,10 @@ export interface ILoggerhythmHook {
 
 export interface ILoggerSubscription {
   dispose(): void;
+}
+
+export interface ILogSettings {
+  [loglevel: string]: {
+    colorFunction: chalk.ChalkChain, logFunction: ILogFunction,
+  };
 }

--- a/src/loggerhythm.ts
+++ b/src/loggerhythm.ts
@@ -45,6 +45,7 @@ if (stdPipesAreAvaliable) {
   };
 }
 
+const namespaceColorFunction: chalk.ChalkChain = chalk.cyan;
 const logSettings: any = {
   [LogLevel.ERROR]: {colorFunction: chalk.red, logFunction: stderrWrite},
   [LogLevel.WARN]: {colorFunction: chalk.yellow, logFunction: stdoutWrite},
@@ -67,7 +68,8 @@ export class Logger {
   constructor(namespace: string = '') {
     this._namespace = namespace;
     for (const logLevel in logSettings) {
-      this.namespaceStrings[logLevel] = ` - ${logSettings[logLevel].colorFunction(logLevel)}: [${namespace}] `;
+      const coloredNamespace: string = namespaceColorFunction(`[${namespace}]`);
+      this.namespaceStrings[logLevel] = ` - ${logSettings[logLevel].colorFunction(logLevel)}: ${coloredNamespace} `;
     }
   }
 

--- a/src/loggerhythm.ts
+++ b/src/loggerhythm.ts
@@ -1,7 +1,7 @@
 import * as chalk from 'chalk';
 import * as util from 'util';
 
-import {ILogFunction, ILoggerhythmHook, ILoggerSubscription, LogLevel} from './interfaces';
+import {ILogFunction, ILoggerhythmHook, ILoggerSubscription, ILogSettings, LogLevel} from './interfaces';
 
 // fallback for browsers
 let stdoutWrite: ILogFunction = console.log;
@@ -46,7 +46,7 @@ if (stdPipesAreAvaliable) {
 }
 
 const namespaceColorFunction: chalk.ChalkChain = chalk.cyan;
-const logSettings: any = {
+const logSettings: ILogSettings = {
   [LogLevel.ERROR]: {colorFunction: chalk.red, logFunction: stderrWrite},
   [LogLevel.WARN]: {colorFunction: chalk.yellow, logFunction: stdoutWrite},
   [LogLevel.INFO]: {colorFunction: chalk.blue, logFunction: stdoutWrite},


### PR DESCRIPTION
This makes the namespace in the logs be cyan. This change makes it way easier to quickly distinguish the namespace from the actual message